### PR TITLE
Fix movie list duplication on refresh

### DIFF
--- a/app/src/main/java/com/menjoo/moviesandroid/cinema/CinemaContract.kt
+++ b/app/src/main/java/com/menjoo/moviesandroid/cinema/CinemaContract.kt
@@ -8,6 +8,7 @@ interface CinemaContract {
 
     interface View : BaseView<Presenter> {
         fun addMoviesToList(moviesToShow: List<Movie>)
+        fun clearMovies()
         fun showLoading()
         fun hideLoading()
         fun showError()

--- a/app/src/main/java/com/menjoo/moviesandroid/cinema/CinemaPresenter.kt
+++ b/app/src/main/java/com/menjoo/moviesandroid/cinema/CinemaPresenter.kt
@@ -51,6 +51,7 @@ class CinemaPresenter(private val movieRepository: MovieRepository,
 
     override fun onRefreshPulled() {
         view.hideError()
+        view.clearMovies()
         view.showLoading()
         loadMovies()
     }

--- a/app/src/main/java/com/menjoo/moviesandroid/cinema/CinemaViewModel.kt
+++ b/app/src/main/java/com/menjoo/moviesandroid/cinema/CinemaViewModel.kt
@@ -24,6 +24,11 @@ class CinemaViewModel : ViewModel(), CinemaContract.View {
         (observableMovies as MutableLiveData).value = movies
     }
 
+    override fun clearMovies() {
+        movies.clear()
+        (observableMovies as MutableLiveData).value = movies
+    }
+
     override fun showLoading() {
         (loading as MutableLiveData).value = true
     }


### PR DESCRIPTION
## Summary
- clear movie list before refreshing
- expose `clearMovies()` on `CinemaContract.View`

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fdc91070c83269124d33028fccc3d